### PR TITLE
fix highlighting of inline comments

### DIFF
--- a/syntax/fish.vim
+++ b/syntax/fish.vim
@@ -20,7 +20,7 @@ syntax match fishCommandSub /\v\(\s*\zs\k+>/
 
 syntax region fishLineContinuation matchgroup=fishStatement
             \ start='\v^\s*\zs\k+>' skip='\\$' end='$'
-            \ contains=fishSpecial,fishIdentifier,fishString,fishCharacter,fishStatement,fishCommandSub
+            \ contains=fishSpecial,fishIdentifier,fishString,fishCharacter,fishStatement,fishCommandSub,fishComment
 
 highlight default link fishKeyword Keyword
 highlight default link fishConditional Conditional


### PR DESCRIPTION
Currently, if comments are on the same line, they aren't highlighted.

``` sh
echo "hi"     # This comment would not be highlighted
```

This pull request fixes that bug.
