### PR TITLE
Escape the current path in keywordprg

### DIFF
--- a/ftplugin/fish.vim
+++ b/ftplugin/fish.vim
@@ -29,7 +29,7 @@ endif
 " Use the 'man' wrapper function in fish to include fish's man pages.
 " Have to use a script for this; 'fish -c man' would make the the man page an
 " argument to fish instead of man.
-execute 'setlocal keywordprg=fish\ '.expand('<sfile>:p:h:h').'/bin/man.fish'
+execute 'setlocal keywordprg=fish\ '.escape(expand('<sfile>:p:h:h'), ' ').'/bin/man.fish'
 
 let b:match_words =
             \ escape('<%(begin|function|if|switch|while|for)>:<end>', '<>%|)')


### PR DESCRIPTION
Fix for current path escaping on OSX

![Screenshot](https://cloud.githubusercontent.com/assets/1501013/9982327/1d10b6a4-5fae-11e5-8c7e-2bc4aef071e7.jpg)
