### PR TITLE
Update plugin to escape path to `bin/man.fish`

### DIFF
--- a/ftplugin/fish.vim
+++ b/ftplugin/fish.vim
@@ -29,7 +29,7 @@ endif
 " Use the 'man' wrapper function in fish to include fish's man pages.
 " Have to use a script for this; 'fish -c man' would make the the man page an
 " argument to fish instead of man.
-execute 'setlocal keywordprg=fish\ '.expand('<sfile>:p:h:h').'/bin/man.fish'
+execute 'setlocal keywordprg=fish\ '.fnameescape(expand('<sfile>:p:h:h').'/bin/man.fish')
 
 let b:match_words =
             \ escape('<%(begin|function|if|switch|while|for)>:<end>', '<>%|)')


### PR DESCRIPTION
Previously an error would throw if the path to `/bin/man.fish` involved spaces or other special characters. This commit escapes the string before having Vim parse it. 

Resolves https://github.com/dag/vim-fish/issues/36#issuecomment-254576309
