### PR TITLE
Clear autocmd to prevent pile-up of `function` declarations

### DIFF
--- a/ftdetect/fish.vim
+++ b/ftdetect/fish.vim
@@ -1,23 +1,28 @@
-autocmd BufRead,BufNewFile *.fish setfiletype fish
+augroup vimfish
 
-" Detect fish scripts by the shebang line.
-autocmd BufRead *
-            \ if getline(1) =~# '\v^#!%(\f*/|/usr/bin/env\s*<)fish>' |
-            \     setlocal filetype=fish |
-            \ endif
+  autocmd!
 
-" Move cursor to first empty line when using funced.
-autocmd BufRead fish_funced_*_*.fish call search('^$')
+  autocmd BufRead,BufNewFile *.fish setfiletype fish
 
-" Fish histories are YAML documents.
-autocmd BufRead,BufNewFile ~/.config/fish/fish_{read_,}history setfiletype yaml
+  " Detect fish scripts by the shebang line.
+  autocmd BufRead *
+              \ if getline(1) =~# '\v^#!%(\f*/|/usr/bin/env\s*<)fish>' |
+              \     setlocal filetype=fish |
+              \ endif
 
-" Universal variable storages should not be hand edited.
-autocmd BufRead,BufNewFile ~/.config/fish/fishd.* setlocal readonly
+  " Move cursor to first empty line when using funced.
+  autocmd BufRead fish_funced_*_*.fish call search('^$')
 
-" Mimic `funced` when manually creating functions.
-autocmd BufNewFile ~/.config/fish/functions/*.fish
-            \ call append(0, ['function '.expand('%:t:r'),
-                             \'',
-                             \'end']) |
-            \ 2
+  " Fish histories are YAML documents.
+  autocmd BufRead,BufNewFile ~/.config/fish/fish_{read_,}history setfiletype yaml
+
+  " Universal variable storages should not be hand edited.
+  autocmd BufRead,BufNewFile ~/.config/fish/fishd.* setlocal readonly
+
+  " Mimic `funced` when manually creating functions.
+  autocmd BufNewFile ~/.config/fish/functions/*.fish
+              \ call append(0, ['function '.expand('%:t:r'),
+                               \'',
+                               \'end']) |
+              \ 2
+augroup END

--- a/ftdetect/fish.vim
+++ b/ftdetect/fish.vim
@@ -1,28 +1,25 @@
-augroup vimfish
+autocmd!
 
-  autocmd!
+autocmd BufRead,BufNewFile *.fish setfiletype fish
 
-  autocmd BufRead,BufNewFile *.fish setfiletype fish
+" Detect fish scripts by the shebang line.
+autocmd BufRead *
+            \ if getline(1) =~# '\v^#!%(\f*/|/usr/bin/env\s*<)fish>' |
+            \     setlocal filetype=fish |
+            \ endif
 
-  " Detect fish scripts by the shebang line.
-  autocmd BufRead *
-              \ if getline(1) =~# '\v^#!%(\f*/|/usr/bin/env\s*<)fish>' |
-              \     setlocal filetype=fish |
-              \ endif
+" Move cursor to first empty line when using funced.
+autocmd BufRead fish_funced_*_*.fish call search('^$')
 
-  " Move cursor to first empty line when using funced.
-  autocmd BufRead fish_funced_*_*.fish call search('^$')
+" Fish histories are YAML documents.
+autocmd BufRead,BufNewFile ~/.config/fish/fish_{read_,}history setfiletype yaml
 
-  " Fish histories are YAML documents.
-  autocmd BufRead,BufNewFile ~/.config/fish/fish_{read_,}history setfiletype yaml
+" Universal variable storages should not be hand edited.
+autocmd BufRead,BufNewFile ~/.config/fish/fishd.* setlocal readonly
 
-  " Universal variable storages should not be hand edited.
-  autocmd BufRead,BufNewFile ~/.config/fish/fishd.* setlocal readonly
-
-  " Mimic `funced` when manually creating functions.
-  autocmd BufNewFile ~/.config/fish/functions/*.fish
-              \ call append(0, ['function '.expand('%:t:r'),
-                               \'',
-                               \'end']) |
-              \ 2
-augroup END
+" Mimic `funced` when manually creating functions.
+autocmd BufNewFile ~/.config/fish/functions/*.fish
+            \ call append(0, ['function '.expand('%:t:r'),
+                             \'',
+                             \'end']) |
+            \ 2


### PR DESCRIPTION
This solves a problem with the .vimrc being sourced more than once, which is a common occurrence.