### PR TITLE
use standard shell definition for iskeyword

### DIFF
--- a/ftplugin/fish.vim
+++ b/ftplugin/fish.vim
@@ -5,7 +5,6 @@ setlocal foldexpr=fish#Fold()
 setlocal formatoptions+=ron1
 setlocal formatoptions-=t
 setlocal include=\\v^\\s*\\.>
-setlocal iskeyword=@,48-57,-,_,.,/
 setlocal suffixesadd^=.fish
 
 " Use the 'j' format option when available.


### PR DESCRIPTION
Prior to this, a `w` would skip over the entirety of /some/long/path-name. This
is probably not what users expect, since they can use `W` for that.