### PR TITLE
Fix indentation

### DIFF
--- a/autoload/fish.vim
+++ b/autoload/fish.vim
@@ -15,7 +15,7 @@ function! fish#Indent()
     if l:line =~# '\v^\s*end>'
         return indent(l:prevlnum) - (l:indent ==# 0 ? l:shiftwidth : l:indent)
     elseif l:line =~# '\v^\s*%(case|else)>'
-        return indent(v:lnum) - l:shiftwidth
+        return indent(l:prevlnum) - l:shiftwidth
     endif
     return indent(l:prevlnum) + l:indent
 endfunction

--- a/autoload/fish.vim
+++ b/autoload/fish.vim
@@ -13,7 +13,7 @@ function! fish#Indent()
     endif
     let l:line = getline(v:lnum)
     if l:line =~# '\v^\s*end>'
-        return indent(v:lnum) - (l:indent ==# 0 ? l:shiftwidth : l:indent)
+        return indent(l:prevlnum) - (l:indent ==# 0 ? l:shiftwidth : l:indent)
     elseif l:line =~# '\v^\s*%(case|else)>'
         return indent(v:lnum) - l:shiftwidth
     endif

--- a/autoload/fish.vim
+++ b/autoload/fish.vim
@@ -1,23 +1,41 @@
 function! fish#Indent()
-    let l:shiftwidth = shiftwidth()
     let l:prevlnum = prevnonblank(v:lnum - 1)
     if l:prevlnum ==# 0
         return 0
     endif
-    let l:indent = 0
     let l:prevline = getline(l:prevlnum)
-    if l:prevline =~# '\v^\s*switch>'
-        return indent(l:prevlnum) + l:shiftwidth
-    elseif l:prevline =~# '\v^\s*%(begin|if|else|while|for|function|case)>'
-        let l:indent = l:shiftwidth
-    endif
     let l:line = getline(v:lnum)
-    if l:line =~# '\v^\s*end>'
-        return indent(l:prevlnum) - (l:indent ==# 0 ? l:shiftwidth : l:indent)
-    elseif l:line =~# '\v^\s*%(case|else)>'
-        return indent(l:prevlnum) - l:shiftwidth
+    let l:shiftwidth = shiftwidth()
+    let l:previndent = indent(l:prevlnum)
+    let l:indent = l:previndent
+    if l:prevline =~# '\v^\s*%(begin|if|else|while|for|function|switch|case)>'
+        let l:indent += l:shiftwidth
     endif
-    return indent(l:prevlnum) + l:indent
+    if l:line =~# '\v^\s*end>'
+        let l:indent -= l:shiftwidth
+        " If we're inside a case, dedent twice because it ends the switch.
+        if l:prevline =~# '\v^\s*case>'
+            " Previous line starts the case.
+            let l:indent -= l:shiftwidth
+        else
+            " Scan back to a dedented line to find whether we're in a case.
+            let l:i = l:prevlnum
+            while l:i >= 1 && indent(l:i) >= l:previndent
+                let l:i = prevnonblank(l:i - 1)
+            endwhile
+            if indent(l:i) < l:previndent && getline(l:i) =~# '\v^\s*case>'
+                let l:indent -= l:shiftwidth
+            endif
+        endif
+    elseif l:line =~# '\v^\s*else>'
+        let l:indent -= l:shiftwidth
+    elseif l:prevline !~# '\v^\s*switch>' && l:line =~# '\v^\s*case>'
+        let l:indent -= l:shiftwidth
+    endif
+    if l:indent < 0
+        return 0
+    endif
+    return l:indent
 endfunction
 
 function! fish#Format()

--- a/autoload/fish.vim
+++ b/autoload/fish.vim
@@ -52,7 +52,7 @@ function! fish#Complete(findstart, base)
         let l:completions =
                     \ system('fish -c "complete -C'.shellescape(a:base).'"')
         let l:cmd = substitute(a:base, '\v\S+$', '', '')
-        for l:line in split(l:completions, '\n')
+        for l:line in filter(split(l:completions, '\n'), 'len(v:val)')
             let l:tokens = split(l:line, '\t')
             call add(l:results, {'word': l:cmd.l:tokens[0],
                                 \'abbr': l:tokens[0],

--- a/autoload/fish.vim
+++ b/autoload/fish.vim
@@ -7,7 +7,7 @@ function! fish#Indent()
     let l:indent = 0
     let l:prevline = getline(l:prevlnum)
     if l:prevline =~# '\v^\s*switch>'
-        let l:indent = l:shiftwidth * 2
+        return indent(l:prevlnum) + l:shiftwidth
     elseif l:prevline =~# '\v^\s*%(begin|if|else|while|for|function|case)>'
         let l:indent = l:shiftwidth
     endif

--- a/ftplugin/fish.vim
+++ b/ftplugin/fish.vim
@@ -5,7 +5,6 @@ setlocal foldexpr=fish#Fold()
 setlocal formatoptions+=ron1
 setlocal formatoptions-=t
 setlocal include=\\v^\\s*\\.>
-setlocal iskeyword=@,48-57,-,_,.,/
 setlocal suffixesadd^=.fish
 
 " Use the 'j' format option when available.


### PR DESCRIPTION
This fixes an issue where any `end` statement was getting unindented to the beginning of the line.

![2019-06-03 23 10 02](https://user-images.githubusercontent.com/5918935/58930025-a8098980-870e-11e9-8771-0a93e9447f67.gif)
