### PR TITLE
Filter blank completions

### DIFF
--- a/autoload/fish.vim
+++ b/autoload/fish.vim
@@ -52,7 +52,7 @@ function! fish#Complete(findstart, base)
         let l:completions =
                     \ system('fish -c "complete -C'.shellescape(a:base).'"')
         let l:cmd = substitute(a:base, '\v\S+$', '', '')
-        for l:line in split(l:completions, '\n')
+        for l:line in filter(split(l:completions, '\n'), 'len(v:val)')
             let l:tokens = split(l:line, '\t')
             call add(l:results, {'word': l:cmd.l:tokens[0],
                                 \'abbr': l:tokens[0],


### PR DESCRIPTION
This filters out blank lines from the output of `fish -c "complete -C..."`, which prevents errors when trying to access `l:tokens[0]`, which is an empty list in the case of a blank completion.