### PR TITLE
Add @Spell to appropriate syntax regions

### DIFF
--- a/syntax/fish.vim
+++ b/syntax/fish.vim
@@ -9,11 +9,11 @@ syntax keyword fishConditional if else switch
 syntax keyword fishRepeat while for in
 syntax keyword fishLabel case
 
-syntax match fishComment /#.*/
+syntax match fishComment /#.*/ contains=@Spell
 syntax match fishSpecial /\\$/
 syntax match fishIdentifier /\$[[:alnum:]_]\+/
-syntax region fishString start=/'/ skip=/\\'/ end=/'/
-syntax region fishString start=/"/ skip=/\\"/ end=/"/ contains=fishIdentifier
+syntax region fishString start=/'/ skip=/\\'/ end=/'/ contains=@Spell
+syntax region fishString start=/"/ skip=/\\"/ end=/"/ contains=fishIdentifier,@Spell
 syntax match fishCharacter /\v\\[abefnrtv *?~%#(){}\[\]<>&;"']|\\[xX][0-9a-f]{1,2}|\\o[0-7]{1,2}|\\u[0-9a-f]{1,4}|\\U[0-9a-f]{1,8}|\\c[a-z]/
 syntax match fishStatement /\v;\s*\zs\k+>/
 syntax match fishCommandSub /\v\(\s*\zs\k+>/


### PR DESCRIPTION
Adds @Spell to the fishComment and fishString syntax regions so that
spellchecking is restricted to those regions and does not default to the
entire file.